### PR TITLE
support cmake install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,12 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(ig_lio)
 
-## Compile as C++11, supported in ROS Kinetic and newer
 set(CMAKE_CXX_STANDARD 17)
 
-set(DEFAULT_BUILD_TYPE "Release")
+set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 ${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}   ${OpenMP_C_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
@@ -41,10 +40,13 @@ catkin_package(
 
 include_directories(
   include 
-  ${catkin_INCLUDE_DIRS}
 )
 
-add_executable(ig_lio_node 
+include_directories(SYSTEM
+  ${catkin_INCLUDE_DIRS}	
+)
+
+add_executable(${PROJECT_NAME}_node 
   src/ig_lio_node
   src/pointcloud_preprocess.cpp
   src/lio.cpp
@@ -54,9 +56,27 @@ add_executable(ig_lio_node
   src/faster_voxel_grid.cpp
 )
 
-target_link_libraries(ig_lio_node
+target_link_libraries(${PROJECT_NAME}_node
   ${catkin_LIBRARIES}
   glog
   gflags
   TBB::tbb
 )
+
+install(TARGETS ${PROJECT_NAME}_node
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)
+
+install(DIRECTORY launch/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+  PATTERN ".svn" EXCLUDE)
+
+install(DIRECTORY config/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/config
+  PATTERN ".svn" EXCLUDE)


### PR DESCRIPTION
Allows for `catkin_make install` to work as expected

Additionally, `-Wall` is now only applied to your own code, as 

```cmake
include_directories(SYSTEM
  ${catkin_INCLUDE_DIRS}	
)
```
is marked as a system directory, and therefore ignored.

The only change I would suggest before merging: because the result folder does not exist after `catkin_make install` one would have to create the result for manually, or in `ig_lio_node.cpp`. I am willing to implement that as part of this PR. What do you think? 

