### PR TITLE
save result/log when installed with cmake

### DIFF
--- a/include/ig_lio/logger.hpp
+++ b/include/ig_lio/logger.hpp
@@ -38,14 +38,14 @@ Logger::Logger(int argc, char** argv) {
   FLAGS_alsologtostderr = true;
   FLAGS_log_prefix = true;
 
-  std::string current_path = boost::filesystem::current_path().c_str();
-  std::string log_path = current_path + "/log";
+  auto current_path = boost::filesystem::current_path();
+  auto log_path = current_path / "log";
   if (!boost::filesystem::exists(log_path)) {
     boost::filesystem::create_directories(log_path);
   }
 
   std::cout << "log path: " << log_path << std::endl;
-  FLAGS_log_dir = log_path;
+  FLAGS_log_dir = log_path.string();
 }
 
 // for ROS
@@ -61,13 +61,13 @@ Logger::Logger(int argc, char** argv, std::string current_path) {
   FLAGS_alsologtostderr = true;
   FLAGS_log_prefix = true;
 
-  std::string log_path = current_path + "/log";
+  auto log_path = boost::filesystem::path(current_path) / "log";
   if (!boost::filesystem::exists(log_path)) {
     boost::filesystem::create_directories(log_path);
   }
 
   std::cout << "log path: " << log_path << std::endl;
-  FLAGS_log_dir = log_path;
+  FLAGS_log_dir = log_path.string();
 }
 
 Logger::~Logger() {

--- a/src/ig_lio_node.cpp
+++ b/src/ig_lio_node.cpp
@@ -9,6 +9,7 @@
 #include <ros/ros.h>
 #include <sensor_msgs/Imu.h>
 #include <tf/transform_broadcaster.h>
+#include <boost/filesystem.hpp>
 
 #include <pcl/filters/voxel_grid.h>
 
@@ -16,6 +17,8 @@
 #include "ig_lio/logger.hpp"
 #include "ig_lio/pointcloud_preprocess.h"
 #include "ig_lio/timer.h"
+
+namespace fs = boost::filesystem;
 
 LidarType lidar_type = LidarType::LIVOX;
 constexpr double kAccScale = 9.80665;
@@ -694,10 +697,14 @@ int main(int argc, char** argv) {
   voxel_filter.setLeafSize(0.5, 0.5, 0.5);
 
   // save trajectory
-  std::string result_path = package_path + "/result/lio_odom.txt";
+  fs::path result_path = fs::path(package_path) / "result" / "lio_odom.txt";
+  if (!fs::exists(result_path.parent_path())) {
+    fs::create_directories(result_path.parent_path());	
+  }
+
   odom_stream.open(result_path, std::ios::out);
   if (!odom_stream.is_open()) {
-    LOG(INFO) << "faild to open: " << result_path;
+    LOG(INFO) << "failed to open: " << result_path;
     exit(0);
   }
 


### PR DESCRIPTION
When using `catkin_make install` (see #8), the `result` folder does not exist.

This PR:

* create the result folder if not available
* cleans some usage of boost filesystem in logger

Please let me know if everything worked out for you, I verified with NCD.